### PR TITLE
Feature/time over threshold

### DIFF
--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -294,8 +294,10 @@ const RtRelation DataProcessor::calculateRtRelation(const DriftTimeSpectrum& dtS
  * @param data Event for that the pulses over threshold are to be analyzed
  * @param threshold threshold that must be undershot in order to identify a "pulse"
  * @return A vector containing a list of pulses, each with time of falling and rising edge in ns
+ *
+ * @warning vector contains raw heap pointers, caller should manage deletion himself
  */
-const vector<array<uint16_t,2>> DataProcessor::pulses_over_threshold(const Event& data, unsigned short threshold)
+const vector<array<uint16_t,2>*> DataProcessor::pulses_over_threshold(const Event& data, unsigned short threshold)
 {
 	return pulses_over_threshold(data,threshold,0,data.getSize());
 }
@@ -315,18 +317,20 @@ const vector<array<uint16_t,2>> DataProcessor::pulses_over_threshold(const Event
  * @param from
  * @param to
  * @return A vector containing a list of pulses, each with time of falling and rising edge in ns
+ *
+ * @warning vector contains raw heap pointers, caller should manage deletion himself
  */
-const vector<array<uint16_t, 2>> DataProcessor::pulses_over_threshold(
+const vector<array<uint16_t, 2>*> DataProcessor::pulses_over_threshold(
 		const Event& data, unsigned short threshold, size_t from, size_t to)
 {
-	vector<array<uint16_t,2>> result(0);
+	vector<array<uint16_t,2>*> result(0);
 	bool first_is_rising = data[from] <= threshold ? true : false;
 	bool pulse_ended = !first_is_rising;
 	//comment this if block when we don't want to count cases where the first edge is rising
 	if(first_is_rising)
 	{
-		result.push_back(array<uint16_t,2>());
-		result.back()[0] = 0xFFFF; //error for first is rising - results in negative time over threshold
+		result.push_back(new array<uint16_t,2>());
+		(*result.back())[0] = 0xFFFF; //error for first is rising - results in negative time over threshold
 	}
 
 	//from maximum drift time on: loop over the event to even higher drift times
@@ -335,8 +339,8 @@ const vector<array<uint16_t, 2>> DataProcessor::pulses_over_threshold(
 		//if-else switches a variable in order not to count a single pulse bin per bin
 		if (data[i] <= threshold && pulse_ended)
 		{
-			result.push_back(array<uint16_t,2>());
-			result.back()[0] = ADC_BINS_TO_TIME * i; //ns
+			result.push_back(new array<uint16_t,2>());
+			(*result.back())[0] = ADC_BINS_TO_TIME * i; //ns
 			pulse_ended = false;
 		}
 		//in case we don't want to count cases where the first edge is rising
@@ -346,13 +350,46 @@ const vector<array<uint16_t, 2>> DataProcessor::pulses_over_threshold(
 //		}
 		else if (data[i] > threshold && !pulse_ended)
 		{
-			result.back()[1] = ADC_BINS_TO_TIME * i; //ns
+			(*result.back())[1] = ADC_BINS_TO_TIME * i; //ns
 			pulse_ended = true;
 		}
+	}
+	if(!pulse_ended)
+	{
+		(*result.back())[1] = 0xFFFF; //error for last rising edge missing
 	}
 
 	return result;
 }
+
+/**
+ * Counts the time over threshold for a set of pulse edge times that is passed to this method as parameter.
+ *
+ * @author Stefan Bieschke
+ * @version Alpha 2.0
+ * @date February 5, 2019
+ *
+ * @param pulses A vector containing arrays with times for falling and rising edges of each pulse. Thus, this array
+ * has is as long as the number of identified pulses is long and each contained array has the time of the falling edge in its
+ * [0] entry and the rising edge in its [1] entry.
+ *
+ * @return A vector that contains the time over threshold in nanoseconds for each identified pulse in the passed parameter vector.
+ *
+ * @ensure result.size() == pulses.size()
+ * @note As the time over threshold is an unsigned integer the case of a missing edge should result in very high time over thresholds, as
+ * the time of a missing edge is set to 0xFFFF, which in either case should result in a high time over threshold.
+ */
+const vector<uint16_t> DataProcessor::time_over_threshold(const vector<array<uint16_t, 2>*>& pulses)
+{
+	vector<uint16_t> result(pulses.size());
+	for(int i = 0; i < pulses.size(); i++)
+	{
+		result[i] = (*pulses[i])[1] - (*pulses[i])[0];
+	}
+	return result;
+}
+
+
 //TODO threshold as parameter?
 //TODO possibility to use any other t_max as parameter
 //TODO Test
@@ -385,9 +422,13 @@ const unsigned int DataProcessor::countAfterpulses(const Drifttube& tube)
 			bool pulseEnded = true;
 			Event voltage = tube.getDataSet().getEvent(i);
 			uint16_t threshold = OFFSET_ZERO_VOLTAGE + EVENT_THRESHOLD_VOLTAGE;
-			vector<array<uint16_t, 2>> pulses = pulses_over_threshold(voltage,
+			vector<array<uint16_t, 2>*> pulses = pulses_over_threshold(voltage,
 					threshold, maxDriftTimeBin, voltage.getSize());
 			nAfterPulses += pulses.size();
+			for(array<uint16_t,2>* arr : pulses)
+			{
+				delete [] arr;
+			}
 		} catch (Exception& e)
 		{
 			continue;

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -322,6 +322,11 @@ const vector<array<uint16_t, 2>> DataProcessor::pulses_over_threshold(
 	vector<array<uint16_t,2>> result(0);
 	bool first_is_rising = data[from] < threshold ? true : false;
 	bool pulse_ended = !first_is_rising;
+	if(first_is_rising)
+	{
+		result.push_back(array<uint16_t,2>());
+		result.back()[0] = 0xFFFF; //error for first is rising
+	}
 
 	//from maximum drift time on: loop over the event to even higher drift times
 	for (unsigned int i = from; i < to; i++)

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -371,20 +371,27 @@ const unsigned int DataProcessor::countAfterpulses(const Drifttube& tube)
 	unsigned int nAfterPulses = 0;
 
 	//counting loop
-	for(unsigned int i = 0; i < tube.getDataSet().getSize(); i++)
+	for (unsigned int i = 0; i < tube.getDataSet().getSize(); i++)
 	{
 		//skip events missing due to zero suppression
-		if(tube.getDataSet().getData()[i].get() == nullptr)
+		if (tube.getDataSet().getData()[i].get() == nullptr)
 		{
 			continue;
 		}
 
-		//assume the pulse has already ended
-		bool pulseEnded = true;
-		Event voltage = tube.getDataSet().getEvent(i);
-		uint16_t threshold = EVENT_THRESHOLD_VOLTAGE + OFFSET_ZERO_VOLTAGE;
-		vector<array<uint16_t,2>> pulses = pulses_over_threshold(voltage, threshold, maxDriftTimeBin, voltage.getSize());
-		nAfterPulses += pulses.size();
+		try
+		{
+			//assume the pulse has already ended
+			bool pulseEnded = true;
+			Event voltage = tube.getDataSet().getEvent(i);
+			uint16_t threshold = EVENT_THRESHOLD_VOLTAGE + OFFSET_ZERO_VOLTAGE;
+			vector<array<uint16_t, 2>> pulses = pulses_over_threshold(voltage,
+					threshold, maxDriftTimeBin, voltage.getSize());
+			nAfterPulses += pulses.size();
+		} catch (Exception& e)
+		{
+			continue;
+		}
 	}
 
 	return nAfterPulses;

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -50,6 +50,9 @@ public:
 	static unsigned short findLastFilledBin(const Event& data, unsigned short threshold);
 	static const DriftTimeSpectrum calculateDriftTimeSpectrum(const DataSet& data);
 	static const RtRelation calculateRtRelation(const DriftTimeSpectrum& dtSpect);
+	static const std::vector<std::array<uint16_t,2>> pulses_over_threshold(const Event& data, unsigned short threshold);
+	static const std::vector<std::array<uint16_t,2>> pulses_over_threshold(const Event& data, unsigned short threshold, size_t from, size_t to);
+	static const std::vector<uint16_t> time_over_threshold(const std::vector<array<uint16_t,2>>& pulses);
 	static const unsigned int countAfterpulses(const Drifttube& tube);
 
 private:

--- a/src/DataProcessor.h
+++ b/src/DataProcessor.h
@@ -50,9 +50,9 @@ public:
 	static unsigned short findLastFilledBin(const Event& data, unsigned short threshold);
 	static const DriftTimeSpectrum calculateDriftTimeSpectrum(const DataSet& data);
 	static const RtRelation calculateRtRelation(const DriftTimeSpectrum& dtSpect);
-	static const std::vector<std::array<uint16_t,2>> pulses_over_threshold(const Event& data, unsigned short threshold);
-	static const std::vector<std::array<uint16_t,2>> pulses_over_threshold(const Event& data, unsigned short threshold, size_t from, size_t to);
-	static const std::vector<uint16_t> time_over_threshold(const std::vector<array<uint16_t,2>>& pulses);
+	static const std::vector<std::array<uint16_t,2>*> pulses_over_threshold(const Event& data, unsigned short threshold);
+	static const std::vector<std::array<uint16_t,2>*> pulses_over_threshold(const Event& data, unsigned short threshold, size_t from, size_t to);
+	static const std::vector<uint16_t> time_over_threshold(const std::vector<array<uint16_t,2>*>& pulses);
 	static const unsigned int countAfterpulses(const Drifttube& tube);
 
 private:

--- a/src/EventSizeException.h
+++ b/src/EventSizeException.h
@@ -30,7 +30,7 @@ public:
 	EventSizeException(int event);
 	virtual ~EventSizeException();
 
-	string error();
+	virtual string error();
 private:
 	int _event;
 };

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -7,12 +7,7 @@
 
 #include "Exception.h"
 
-Exception::Exception()
-{
-
-}
-
-Exception::~Exception()
-{
-}
-
+//Exception::Exception()
+//{
+//
+//}

--- a/src/Exception.h
+++ b/src/Exception.h
@@ -30,8 +30,8 @@ using namespace std;
 class Exception
 {
 public:
-	Exception();
-	virtual ~Exception();
+//	Exception();
+//	virtual ~Exception() = 0;
 	virtual string error() = 0;
 };
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -27,6 +27,6 @@ static const unsigned short OFFSET_ZERO_VOLTAGE = 2200; //channels
 static const double DRIFT_TUBE_RADIUS = 18.15;//mm
 
 //values for actual physics:
-static const short EVENT_THRESHOLD_VOLTAGE = -300; //channels relative to OFFSET_ZERO_VOLTAGE
+static const short EVENT_THRESHOLD_VOLTAGE = -100; //channels relative to OFFSET_ZERO_VOLTAGE
 
 #endif /* GLOBALS_H_ */

--- a/src/globals.h
+++ b/src/globals.h
@@ -27,6 +27,6 @@ static const unsigned short OFFSET_ZERO_VOLTAGE = 2200; //channels
 static const double DRIFT_TUBE_RADIUS = 18.15;//mm
 
 //values for actual physics:
-static const short EVENT_THRESHOLD_VOLTAGE = -100; //channels relative to OFFSET_ZERO_VOLTAGE
+static const short EVENT_THRESHOLD_VOLTAGE = -300; //channels relative to OFFSET_ZERO_VOLTAGE
 
 #endif /* GLOBALS_H_ */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,32 @@ int main(int argc, char** argv)
 	}
 	f.close();
 
+	cout << "Time over threshold for threshold -100" << endl;
+
+	for(size_t i = 0; i < archive.getTubes()[0]->getDataSet().getSize(); i++)
+	{
+		try
+		{
+			Event e = archive.getTubes()[0]->getDataSet()[i];
+			vector<array<uint16_t,2>*> edges = DataProcessor::pulses_over_threshold(e, -300 + OFFSET_ZERO_VOLTAGE);
+			vector<uint16_t> time_over_threshold = DataProcessor::time_over_threshold(edges);
+			for(size_t j = 0; j < time_over_threshold.size(); j++)
+			{
+				cout << time_over_threshold[j] << endl;
+			}
+			//delete arrays
+			for(array<uint16_t,2>* arr : edges)
+			{
+				delete [] arr;
+			}
+		}
+		catch(Exception& e)
+		{
+			cerr << e.error() << endl;
+			continue;
+		}
+	}
+
 	//TODO get rid of system call... why system() is evil http://www.cplusplus.com/forum/articles/11153/
 	system("gnuplot -p scripts/plots/dtAndRt.plt");
 


### PR DESCRIPTION
# Content
Calculation of time over threshold (tot) for every pulse in an event. This is a two step process.

1. Detection of falling and rising edges with according times
2. Subtraction of a pair of these timestamps for time over threshold

The first step is now also used in the detection of afterpulses. This way, we can later seperate "real" afterpulses from noise